### PR TITLE
ci(ui): fix failing ui action

### DIFF
--- a/.github/workflows/ui-continuous_integeration.yml
+++ b/.github/workflows/ui-continuous_integeration.yml
@@ -5,10 +5,12 @@ on:
     branches: [master]
     paths:
       - ui/**
+      - .github/workflows/ui-continuous_integration.yml
   pull_request:
     branches: [master]
     paths:
       - ui/**
+      - .github/workflows/ui-continuous_integration.yml
 
 defaults:
   run:
@@ -29,6 +31,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+          cache-dependency-path: ui/package-lock.json
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/ui/src/dummy.test.ts
+++ b/ui/src/dummy.test.ts
@@ -3,3 +3,5 @@ describe('dummy test', () => {
     expect(1 + 2).toEqual(3);
   });
 });
+
+export {};


### PR DESCRIPTION
The ui workflow was failing because node cache action couldn't find `package-lock.json`. 