### PR TITLE
ci(api): remove coverage commenter

### DIFF
--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -5,10 +5,12 @@ on:
     branches: [ master ]
     paths:
       - api/**
+      - .github/workflows/api-build.yml
   pull_request:
     branches: [ master ]
     paths:
       - api/**
+      - .github/workflows/api-build.yml
 
 env:
   PROJECT_SECRET_KEY: random-key
@@ -41,11 +43,6 @@ jobs:
     - name: Run Tests
       run: |
         pytest --cache-clear --cov=api | tee pytest-coverage.txt
-    - name: Pytest coverage comment
-      if: github.event_name == 'pull_request'
-      uses: MishaKav/pytest-coverage-comment@main
-      with:
-        pytest-coverage-path: api/pytest-coverage.txt
 
   flake8-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The coverage commenter action was introduced to comment out coverage of the API on the PR that was raised. This action requires the workflow to have write access to PRs.

The issue is in the forked repositories of users who don't have write access to `gymkhana` repository. When they raise a PR from their repo to `gymkhana` repo, workflows from their repositories are run and the `commenter action` in user repository workflow, does not have write access on original repo's PRs.

This causes workflow to fail with [error](https://github.com/BitByte-TPC/gymkhana/runs/6753223792?check_suite_focus=true)