### PR TITLE
fix(api): remove unnecessary code

### DIFF
--- a/api/api/clubs/views.py
+++ b/api/api/clubs/views.py
@@ -1,5 +1,4 @@
 from rest_framework.generics import ListAPIView
-from rest_framework.response import Response
 
 from .models import Club
 from .serializers import ClubSerializer
@@ -8,4 +7,3 @@ from .serializers import ClubSerializer
 class ListClubsView(ListAPIView):
     queryset = Club.objects.all()
     serializer_class = ClubSerializer
-    Response(data=ClubSerializer(queryset, many=True).data)


### PR DESCRIPTION
fixes: #158

`Club.objects.all()` accesses the club table before it was created and
it wasn't even required, so cleaned it up.