### PR TITLE
feat(api): add endpoint for creating users

### DIFF
--- a/api/api/accounts/models.py
+++ b/api/api/accounts/models.py
@@ -58,7 +58,7 @@ class User(AbstractUser, PermissionsMixin):
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
-    picture_url = models.URLField(max_length=500)
+    picture_url = models.URLField(max_length=500, null=True)
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []

--- a/api/api/accounts/models.py
+++ b/api/api/accounts/models.py
@@ -58,7 +58,7 @@ class User(AbstractUser, PermissionsMixin):
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
-    picture_url = models.URLField(max_length=500, null=True)
+    picture_url = models.URLField(max_length=500, blank=True)
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = []

--- a/api/api/accounts/serializers.py
+++ b/api/api/accounts/serializers.py
@@ -1,6 +1,9 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-from .models import Faculty, Staff, Student, User
+from .models import Faculty, Staff, Student
+
+User = get_user_model()
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -28,7 +31,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ['id', 'email', 'first_name', 'last_name', 'gender',
+        fields = ['email', 'first_name', 'last_name', 'gender',
                   'contact_no', 'user_type', 'picture_url', 'student', 'faculty', 'staff']
 
     def create(self, validated_data):

--- a/api/api/accounts/serializers.py
+++ b/api/api/accounts/serializers.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from .models import Faculty, Staff, Student, User
+
+
+class StudentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Student
+        fields = ['roll_no', 'batch', 'department', 'hostel_address', 'bio']
+
+
+class FacultySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Faculty
+        fields = ['title', 'department', 'designation']
+
+
+class StaffSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Staff
+        fields = ['department', 'designation']
+
+
+class UserSerializer(serializers.ModelSerializer):
+    student = StudentSerializer(many=False, allow_null=True, required=False)
+    faculty = FacultySerializer(many=False, allow_null=True, required=False)
+    staff = StaffSerializer(many=False, allow_null=True, required=False)
+
+    class Meta:
+        model = User
+        fields = ['id', 'email', 'first_name', 'last_name', 'gender',
+                  'contact_no', 'user_type', 'picture_url', 'student', 'faculty', 'staff']
+
+    def create(self, validated_data):
+        student_data = validated_data.pop('student', None)
+        faculty_data = validated_data.pop('faculty', None)
+        staff_data = validated_data.pop('staff', None)
+
+        user = User.objects.create(**validated_data)
+
+        if student_data:
+            Student.objects.create(user=user, **student_data)
+        elif faculty_data:
+            Faculty.objects.create(user=user, **faculty_data)
+        elif staff_data:
+            Staff.objects.create(user=user, **staff_data)
+
+        return user

--- a/api/api/accounts/tests.py
+++ b/api/api/accounts/tests.py
@@ -1,0 +1,132 @@
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+User = get_user_model()
+userCreationEndpoint = '/users/'
+primaryTestUserMail = 'test@user.com'
+
+
+class UsersListViewTest(APITestCase):
+
+    @pytest.mark.django_db
+    def testUsersListView_testBaseUserModel_validEmailProvided_userSuccessfullyCreated(self):
+        # given
+        user = User.objects.create(
+            email=primaryTestUserMail, first_name='Test', last_name='User')
+        self.client.force_authenticate(user)
+        testUserEmail = 'test1@user.com'
+
+        # when
+        response = self.client.post(userCreationEndpoint, {'email': testUserEmail}, format='json')
+
+        # then
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['email'], testUserEmail)
+
+    @pytest.mark.django_db
+    def testUsersListView_invalidEmailsProvided_returnsHttp400(self):
+        # given
+        user = User.objects.create(
+            email=primaryTestUserMail, first_name='Test', last_name='User')
+        self.client.force_authenticate(user)
+
+        invalidTestMail1 = primaryTestUserMail
+        invalidTestMail2 = ''
+        invalidTestMail3 = 'testusercom'
+
+        # when
+        response1 = self.client.post(userCreationEndpoint, {'email': invalidTestMail1},
+                                     format='json')
+        response2 = self.client.post(userCreationEndpoint, {'email': invalidTestMail2},
+                                     format='json')
+        response3 = self.client.post(userCreationEndpoint, {'email': invalidTestMail3},
+                                     format='json')
+
+        # then
+        self.assertEqual(response1.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response2.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response3.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @pytest.mark.django_db
+    def testUsersListView_testStudentModel_validDataProvided_userSuccessfullyCreated(self):
+        # given
+        user = User.objects.create(
+            email='test@user.com', first_name='Test', last_name='User')
+        self.client.force_authenticate(user)
+
+        testUserEmail = 'test@student.com'
+
+        # when
+        response = self.client.post(userCreationEndpoint,
+                                    {
+                                      'email': testUserEmail,
+                                      'first_name': "test",
+                                      'user_type': 'Student',
+                                      'student': {
+                                          'roll_no': "21abc000",
+                                          'batch': 2025,
+                                          'department': "CSE",
+                                          'hostel_address': "H3-Z000"
+                                      }
+                                    })
+
+        # then
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['email'], testUserEmail)
+        self.assertEqual(response.data['student']['roll_no'], '21abc000')
+
+    @pytest.mark.django_db
+    def testUserListView_testFacultyModel_validDataProvided_userSuccessfullyCreated(self):
+        # given
+        user = User.objects.create(
+            email='test@user.com', first_name='Test', last_name='User')
+        self.client.force_authenticate(user)
+
+        testUserEmail = 'test@faculty.com'
+
+        # when
+        response = self.client.post(userCreationEndpoint,
+                                    {
+                                      'email': testUserEmail,
+                                      'gender': 'F',
+                                      'user_type': 'Faculty',
+                                      'faculty': {
+                                          'title': 'Prof',
+                                          'department': 'ECE',
+                                          'designation': 'z'
+                                      }
+                                    })
+
+        # then
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['email'], testUserEmail)
+        self.assertEqual(response.data['faculty']['title'], 'Prof')
+
+    @pytest.mark.django_db
+    def testUserListView_testStaffModel_validDataProvided_userSuccessfullyCreated(self):
+        # given
+        user = User.objects.create(
+            email='test@user.com', first_name='Test', last_name='User')
+        self.client.force_authenticate(user)
+
+        testUserEmail = 'test@staff.com'
+
+        # when
+        response = self.client.post(userCreationEndpoint,
+                                    {
+                                      'email': testUserEmail,
+                                      'gender': 'M',
+                                      'last_name': 'Staff',
+                                      'user_type': 'Staff',
+                                      'staff': {
+                                          'department': 'ECE',
+                                          'designation': 'z'
+                                      }
+                                    })
+
+        # then
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['email'], testUserEmail)
+        self.assertEqual(response.data['staff']['department'], 'ECE')

--- a/api/api/accounts/urls.py
+++ b/api/api/accounts/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+  path('', views.UsersListView.as_view()),
+]

--- a/api/api/accounts/urls.py
+++ b/api/api/accounts/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-  path('', views.UsersListView.as_view()),
+  path('', views.CreateUserView.as_view()),
 ]

--- a/api/api/accounts/views.py
+++ b/api/api/accounts/views.py
@@ -1,0 +1,12 @@
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
+
+from .models import User
+from .serializers import UserSerializer
+
+
+class UsersListView(generics.CreateAPIView):
+    """ View to create users """
+    permission_classes = (AllowAny,)
+    queryset = User.objects.all()
+    serializer_class = UserSerializer

--- a/api/api/accounts/views.py
+++ b/api/api/accounts/views.py
@@ -1,12 +1,14 @@
+from django.contrib.auth import get_user_model
 from rest_framework import generics
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAdminUser
 
-from .models import User
 from .serializers import UserSerializer
 
+User = get_user_model()
 
-class UsersListView(generics.CreateAPIView):
+
+class CreateUserView(generics.CreateAPIView):
     """ View to create users """
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAdminUser,)
     queryset = User.objects.all()
     serializer_class = UserSerializer

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('auth/', include('api.auth.urls')),
     path('clubs/', include('api.clubs.urls')),
     path('ping/', ping_handler, name='ping'),
+    path('users/', include('api.accounts.urls')),
 ]
 
 if os.environ.get('ENV') == 'dev':


### PR DESCRIPTION
+ `view` : generic CreateAPI view
+ `Post` request at `/users/` for creating users
+ ` Serializers` 
  + Simple Model Serializers for `Faculty`, `Student` and `Staff`
  + These three serializers are nested inside `UserSerializer` and their `required` attribute is set to `False`
  + The `create` method then extracts data of each Serializer(if present) and the remaining data is used to create the user. And depending on the extracted data, the student, faculty and staff instances are created.
  +  The problem I was facing in this implementation was that a User could be only one of staff, faculty and student. I've have handled it by assuming only one or neither of them would be passed to the api. Let me know if the design could have been better.
+ `testing`: I have added some test to cover different scenarios like adding base User, Student, Faculty etc, and what should happen when invalid emails are provided