### PR TITLE
refactor(api): general refactoring

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -2,6 +2,5 @@ PROJECT_SECRET_KEY=my-secret
 ENV=dev
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 ALLOWED_HOSTS=localhost,127.0.0.1
-DJANGO_SETTINGS_MODULE=api.settings.dev
 GOOGLE_OAUTH2_CLIENT_ID=<replace with your own key>
 GOOGLE_OAUTH2_CLIENT_SECRET=<replace with your own secret>

--- a/api/api/dev_urls.py
+++ b/api/api/dev_urls.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+from django.urls import include, path
+
+from api.urls import urlpatterns
+
+urlpatterns += [
+    path(
+        'api-auth/',
+        include('rest_framework.urls', namespace='rest_framework')),
+    path('admin/', admin.site.urls),
+]

--- a/api/api/events/models.py
+++ b/api/api/events/models.py
@@ -1,6 +1,7 @@
-from clubs.models import Club
 from django.contrib.auth import get_user_model
 from django.db import models
+
+from api.clubs.models import Club
 
 User = get_user_model()
 

--- a/api/api/settings/dev.py
+++ b/api/api/settings/dev.py
@@ -3,13 +3,19 @@ from .settings import *  # noqa: F403
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = [  # noqa: F405
+    'rest_framework.authentication.SessionAuthentication'
+] + REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES']  # noqa: F405
+
 
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',  # noqa: F405
     }
 }
+
+
+ROOT_URLCONF = 'api.dev_urls'

--- a/api/api/settings/prod.py
+++ b/api/api/settings/prod.py
@@ -5,6 +5,7 @@ from .settings import *  # noqa: F403, F401
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = ['rest_framework.renderers.JSONRenderer']  # noqa: F405
 
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
@@ -15,7 +16,7 @@ DATABASES = {
         'NAME': os.environ.get('DB_POSTGRES_NAME'),
         'USER': os.environ.get('DB_POSTGRES_USER'),
         'PASSWORD': os.environ.get('DB_POSTGRES_PASSWORD'),
-        'HOST': os.environ['DB_POSTGRES_HOST'],
-        'PORT': os.environ['DB_POSTGRES_PORT'],
+        'HOST': os.environ.get('DB_POSTGRES_HOST'),
+        'PORT': os.environ.get('DB_POSTGRES_PORT'),
     }
 }

--- a/api/api/settings/settings.py
+++ b/api/api/settings/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'api.auth',
     'api.accounts',
     'api.clubs',
+    'api.events',
     'api.roles',
 ]
 
@@ -64,9 +65,9 @@ REST_FRAMEWORK = {
     'TEST_REQUEST_RENDERER_CLASSES': [
         'rest_framework.renderers.JSONRenderer'
     ],
-    'DEFAULT_AUTHENTICATION_CLASSES': (
+    'DEFAULT_AUTHENTICATION_CLASSES': [
         'api.auth.backend.TokenHeaderAuthentication',
-    ),
+    ],
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     )

--- a/api/api/tests.py
+++ b/api/api/tests.py
@@ -1,8 +1,6 @@
 import functools
-import os
 import sys
 from importlib import import_module, reload
-from unittest import mock
 
 import pytest
 from django.conf import settings
@@ -29,7 +27,7 @@ def reload_root_urls(wrapped):
 class AdminEndpointTest(APITestCase):
 
     @pytest.mark.order(1)
-    @mock.patch.dict(os.environ, {'ENV': 'dev'})
+    @pytest.mark.urls('api.dev_urls')
     @reload_root_urls
     def testAdminEndpoint_inDevEnv_returns200Ok(self):
         """Tests the /admin/ endpoint to return status code 200 when env is dev"""
@@ -38,6 +36,7 @@ class AdminEndpointTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @pytest.mark.order(2)
+    @pytest.mark.urls('api.urls')
     @reload_root_urls
     def testAdminEndpoint_notInDevEnv_returns404(self):
         """Tests the /admin/ endpoint to return status code 404 when env is not dev"""

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -1,18 +1,11 @@
-import os
-
-from django.contrib import admin
 from django.urls import path
 from django.urls.conf import include
 
 from .views import ping_handler
 
 urlpatterns = [
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('auth/', include('api.auth.urls')),
     path('clubs/', include('api.clubs.urls')),
     path('ping/', ping_handler, name='ping'),
     path('users/', include('api.accounts.urls')),
 ]
-
-if os.environ.get('ENV') == 'dev':
-    urlpatterns.append(path('admin/', admin.site.urls))

--- a/api/manage.py
+++ b/api/manage.py
@@ -9,7 +9,8 @@ from dotenv import load_dotenv
 def main():
     """Run administrative tasks."""
     load_dotenv()
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'api.settings.dev')
+    application_env = os.environ.get("ENV", "prod")
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', f'api.settings.{application_env}')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
- adds separet URL_CONF for dev env: `dev_urls.py`
- uses `@pytest.mark.urls` for changing URL_CONF for multiple tests
- fixes import in `api.events.models`
- Disables BrowsableAPI in prod env
- Allows Session Authentication for Browsable API in dev env
- Uses just `ENV` to deduce which settings module to use
