### PR TITLE
feat(api): add endpoint to list and create events

### DIFF
--- a/api/api/auth/models.py
+++ b/api/api/auth/models.py
@@ -21,7 +21,7 @@ class Token(models.Model):
     @staticmethod
     def if_expired_get_new(token, user):
         token_life = (datetime.now(timezone.utc) - token.created_at).days
-        if(token_life >= settings.AUTH_ALLOWED_TOKEN_LIFE_IN_DAYS):
+        if (token_life >= settings.AUTH_ALLOWED_TOKEN_LIFE_IN_DAYS):
             token.delete()
             return Token.objects.create(token=uuid.uuid4().hex, user=user)
         return token

--- a/api/api/auth/models.py
+++ b/api/api/auth/models.py
@@ -21,7 +21,7 @@ class Token(models.Model):
     @staticmethod
     def if_expired_get_new(token, user):
         token_life = (datetime.now(timezone.utc) - token.created_at).days
-        if (token_life >= settings.AUTH_ALLOWED_TOKEN_LIFE_IN_DAYS):
+        if token_life >= settings.AUTH_ALLOWED_TOKEN_LIFE_IN_DAYS:
             token.delete()
             return Token.objects.create(token=uuid.uuid4().hex, user=user)
         return token

--- a/api/api/events/models.py
+++ b/api/api/events/models.py
@@ -1,7 +1,6 @@
+from api.clubs.models import Club
 from django.contrib.auth import get_user_model
 from django.db import models
-
-from api.clubs.models import Club
 
 User = get_user_model()
 

--- a/api/api/events/serializers.py
+++ b/api/api/events/serializers.py
@@ -1,0 +1,10 @@
+from api.events.models import Events
+from rest_framework import serializers
+
+
+class EventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Events
+        fields = ['id', 'name', 'description', 'starts_at', 'ends_at', 'registration_required',
+                  'created_by', 'image_url', 'club', 'registration_approval_required', 'address']
+        extra_kwargs = {'id': {'read_only': True}}

--- a/api/api/events/test_list_create_events.py
+++ b/api/api/events/test_list_create_events.py
@@ -1,0 +1,173 @@
+import pytest
+from api.clubs.models import Club
+from api.events.models import Events
+from api.roles.models import Roles
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope='function')
+def test_user(django_user_model):
+    return django_user_model.objects.create(email='test@user.com',
+                                            first_name='test',
+                                            last_name='User')
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope='function')
+def test_club(django_user_model):
+    return Club.objects.create(name="Bitbyte - The Programming Club",
+                               category="S&T",
+                               description="Some desc",
+                               email="theprogclub@iiitdmj.ac.in",
+                               logo="https://www.iiitdmj.ac.in/webix.iiitdmj.ac.in/tpclogo.png")
+
+
+@pytest.fixture(scope='function')
+def client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def testListEvents_noEventsInDb_returnsEmptyList(test_user, client):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    response = client.get('/events/', format='json')
+
+    # then
+    assert response.data['count'] == 0
+
+
+@pytest.mark.django_db
+def testListEvents_oneEventInDb_returnsOneEventInResponse(client, test_user, test_club):
+    # given
+    client.force_authenticate(test_user)
+
+    Events.objects.create(name='Introduction to Git and Github',
+                          description='some desc',
+                          starts_at='2022-08-07',
+                          ends_at='2022-08-07',
+                          image_url='https://asite.com',
+                          address='c',
+                          club=test_club)
+
+    # when
+    response = client.get('/events/', format='json')
+
+    # then
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data['count'] == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('position', ['Core member', 'Coordinator', 'Co-Coordinator'])
+def testCreateEvents_coreMemberRequest_creationSuccessful(client, test_user, test_club, position):
+    # given
+    client.force_authenticate(test_user)
+    Roles.objects.create(name=position,
+                         club=test_club,
+                         user=test_user,
+                         assigned_at='2022-08-01')
+
+    # when
+    response = client.post('/events/', {'name': 'Introduction to Git and Github',
+                                        'description': 'some desc',
+                                        'starts_at': '2022-08-07',
+                                        'ends_at': '2022-08-07',
+                                        'image_url': 'https://asite.com',
+                                        'address': 'c',
+                                        'club': test_club.id
+                                        })
+
+    # then
+    created_event = Events.objects.all()[0]
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data == {'id': created_event.id,
+                             'name': 'Introduction to Git and Github',
+                             'description': 'some desc',
+                             'starts_at': '2022-08-07',
+                             'ends_at': '2022-08-07',
+                             'registration_required': False,
+                             'created_by': None,
+                             'image_url': 'https://asite.com',
+                             'club': 1,
+                             'registration_approval_required': False,
+                             'address': 'c'}
+    assert created_event.name == 'Introduction to Git and Github'
+
+
+@pytest.mark.django_db
+def testCreateEvents_adminRequest_creationSuccessful(client, test_user, test_club):
+    # given
+    test_user.is_staff = True
+    client.force_authenticate(test_user)
+
+    # when
+    response = client.post('/events/', {'name': 'Introduction to Git and Github',
+                                        'description': 'some desc',
+                                        'starts_at': '2022-08-07',
+                                        'ends_at': '2022-08-07',
+                                        'image_url': 'https://asite.com',
+                                        'address': 'c',
+                                        'club': test_club.id
+                                        })
+
+    # then
+    created_event = Events.objects.all()[0]
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data == {'id': created_event.id,
+                             'name': 'Introduction to Git and Github',
+                             'description': 'some desc',
+                             'starts_at': '2022-08-07',
+                             'ends_at': '2022-08-07',
+                             'registration_required': False,
+                             'created_by': None,
+                             'image_url': 'https://asite.com',
+                             'club': 1,
+                             'registration_approval_required': False,
+                             'address': 'c'}
+    assert created_event.name == 'Introduction to Git and Github'
+
+
+@pytest.mark.django_db
+def testCreateEvents_unauthorizedUserRequest_throwsForbidden(client, test_user, test_club):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    response = client.post('/events/', {'name': 'Introduction to Git and Github',
+                                        'description': 'some desc',
+                                        'starts_at': '2022-08-07',
+                                        'ends_at': '2022-08-07',
+                                        'image_url': 'https://asite.com',
+                                        'address': 'c',
+                                        'club': test_club.id
+                                        })
+    # then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def testCreateEvents_missingDataInRequest_throwsBasRequest(client, test_user, test_club):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    # request missing start and end time
+    response = client.post('/events/', {'name': 'Introduction to Git and Github',
+                                        'description': 'some desc',
+                                        'image_url': 'https://asite.com',
+                                        'address': 'c',
+                                        'club': test_club.id
+                                        })
+
+    # then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/api/api/events/urls.py
+++ b/api/api/events/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.ListCreateEventsView.as_view()),
+]

--- a/api/api/events/views.py
+++ b/api/api/events/views.py
@@ -17,7 +17,7 @@ class ListCreateEventsView(ListCreateAPIView):
         if self._has_create_permission(serializer.validated_data):
             serializer.save()
         else:
-            raise PermissionDenied({"message": "You are not allowed to perform this action"})
+            raise PermissionDenied({'message': 'You are not allowed to perform this action'})
 
     # Allow only Core members (including Coordinator and Co-Coordinator)
     # and admins to create events

--- a/api/api/events/views.py
+++ b/api/api/events/views.py
@@ -2,12 +2,14 @@ from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import ListCreateAPIView
 
+from api.roles.models import Roles
+
 from .models import Events
 from .serializers import EventSerializer
 
 
 class ListCreateEventsView(ListCreateAPIView):
-    """ View to list and create users """
+    """ View to list and create events """
     queryset = Events.objects.all()
     serializer_class = EventSerializer
 
@@ -21,7 +23,9 @@ class ListCreateEventsView(ListCreateAPIView):
     # and admins to create events
     def _has_create_permission(self, validated_data):
         allowed_roles = validated_data['club'].roles.filter(
-                        Q(name='Core member') | Q(name='Coordinator') | Q(name='Co-Coordinator'))
+                        Q(name=Roles.ROLE_CORE_MEMBER) |
+                        Q(name=Roles.ROLE_COORDINATOR) |
+                        Q(name=Roles.ROLE_CO_COORDINATOR))
         user_roles = self.request.user.roles.filter(club__id=validated_data['club'].id)
 
         return (self.request.user.is_staff or (allowed_roles & user_roles).exists())

--- a/api/api/events/views.py
+++ b/api/api/events/views.py
@@ -1,0 +1,27 @@
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.generics import ListCreateAPIView
+
+from .models import Events
+from .serializers import EventSerializer
+
+
+class ListCreateEventsView(ListCreateAPIView):
+    """ View to list and create users """
+    queryset = Events.objects.all()
+    serializer_class = EventSerializer
+
+    def perform_create(self, serializer):
+        if self._has_create_permission(serializer.validated_data):
+            serializer.save()
+        else:
+            raise PermissionDenied({"message": "You are not allowed to perform this action"})
+
+    # Allow only Core members (including Coordinator and Co-Coordinator)
+    # and admins to create events
+    def _has_create_permission(self, validated_data):
+        allowed_roles = validated_data['club'].roles.filter(
+                        Q(name='Core member') | Q(name='Coordinator') | Q(name='Co-Coordinator'))
+        user_roles = self.request.user.roles.filter(club__id=validated_data['club'].id)
+
+        return (self.request.user.is_staff or (allowed_roles & user_roles).exists())

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('clubs/', include('api.clubs.urls')),
     path('ping/', ping_handler, name='ping'),
     path('users/', include('api.accounts.urls')),
+    path('events/', include('api.events.urls')),
 ]


### PR DESCRIPTION
Event create access is given to `core members`, `co-coordinators`, and `coordinators`.