### PR TITLE
feat(api): add enpoint for club registration

### DIFF
--- a/api/api/clubs/models.py
+++ b/api/api/clubs/models.py
@@ -25,7 +25,7 @@ class Club (models.Model):
     registration_deadline = models.DateTimeField(blank=True, null=True)
 
 
-class ClubRegistrationRequests(models.Model):
+class ClubRegistrationRequest(models.Model):
     class RegistrationStatus(models.TextChoices):
         PENDING = 'Pending', _('Pending')
         APPROVED = 'Approved', _('Approved')

--- a/api/api/clubs/permissions.py
+++ b/api/api/clubs/permissions.py
@@ -1,13 +1,35 @@
 from django.db.models import Q
 from rest_framework import permissions
 
+from api.roles.models import Role
+
 
 class IsPositionHolderOrAdmin(permissions.BasePermission):
     """Custom permission to allow only position holders of respective club and admins"""
 
     def has_object_permission(self, request, view, obj):
-        allowed_roles = obj.roles.filter(Q(name='Coordinator') | Q(name='Co-Coordinator'))
+        allowed_roles = obj.roles.filter(Q(name=Role.ROLE_COORDINATOR) | Q(
+            name=Role.ROLE_CO_COORDINATOR) | Q(name=Role.ROLE_CORE_MEMBER))
         user_roles = request.user.roles.filter(club__id=obj.id)
+
+        # return true when allowed_roles and users roles have common elements
+        return (request.user.is_staff or (allowed_roles & user_roles).exists())
+
+
+class IsCoreMemberOrAdmin(permissions.BasePermission):
+    """Custom permission to allow only core members of respective club and admins"""
+
+    def has_permission(self, request, view):
+        user_roles = request.user.roles.filter(Q(name=Role.ROLE_COORDINATOR) | Q(
+            name=Role.ROLE_CO_COORDINATOR) | Q(name=Role.ROLE_CORE_MEMBER))
+
+        # return true when allowed_roles and users roles have common elements
+        return (request.user.is_staff or user_roles.exists())
+
+    def has_object_permission(self, request, view, obj):
+        allowed_roles = obj.club.roles.filter(Q(name=Role.ROLE_COORDINATOR) | Q(
+            name=Role.ROLE_CO_COORDINATOR) | Q(name=Role.ROLE_CORE_MEMBER))
+        user_roles = request.user.roles.filter(club__id=obj.club.id)
 
         # return true when allowed_roles and users roles have common elements
         return (request.user.is_staff or (allowed_roles & user_roles).exists())

--- a/api/api/clubs/serializers.py
+++ b/api/api/clubs/serializers.py
@@ -1,6 +1,7 @@
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
-from api.clubs.models import Club
+from api.clubs.models import Club, ClubRegistrationRequest
 
 
 class ClubSerializer(serializers.ModelSerializer):
@@ -10,3 +11,41 @@ class ClubSerializer(serializers.ModelSerializer):
         extra_kwargs = {'id': {'read_only': True},
                         'slug': {'read_only': True}
                         }
+
+
+class ClubRegistrationRequestSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ClubRegistrationRequest
+        fields = ['id', 'user', 'club', 'fee_submitted', 'status', 'remark', 'updated_at']
+        extra_kwargs = {'id': {'read_only': True}, 'user': {
+            'read_only': True}, 'club': {'read_only': True}, 'updated_at': {'read_only': True}}
+
+    def create(self, validated_data):
+        user = self.context['request'].user
+        club_id = self.context['view'].kwargs.get('pk')
+        try:
+            club = Club.objects.get(id=club_id)
+            return ClubRegistrationRequest.objects.create(user=user, club=club, **validated_data)
+        except ObjectDoesNotExist:
+            raise serializers.ValidationError({'detail': 'invalid request'})
+
+
+class ClubUpdateRegistrationRequestSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ClubRegistrationRequest
+        fields = ['id', 'user', 'club', 'fee_submitted',
+                  'status', 'remark', 'updated_by', 'updated_at']
+        extra_kwargs = {'id': {'read_only': True}, 'user': {'read_only': True},
+                        'club': {'read_only': True}, 'updated_by': {'read_only': True},
+                        'updated_at': {'read_only': True}}
+
+    def update(self, instance, validated_data):
+        updatable_fields = ['fee_submitted', 'status', 'remark']
+        upadted_by = self.context['request'].user
+        for field in updatable_fields:
+            field_stored_value = getattr(instance, field)
+            field_new_value = validated_data.get(field, field_stored_value)
+            setattr(instance, field, field_new_value)
+        setattr(instance, 'updated_by', upadted_by)
+        instance.save()
+        return instance

--- a/api/api/clubs/tests.py
+++ b/api/api/clubs/tests.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from api.clubs.models import Club
+from api.clubs.views import ClubRegistrationRequest
 from api.roles.models import Role
 
 User = get_user_model()
@@ -191,3 +192,196 @@ def testUpdateClubs_positionHolderRequest_updatesSuccessful(position):
     assert updated_club.category == 'Cultural'
     assert updated_club.logo == 'https://changedlogo.com'
     assert updated_club.email, 'theprogclub@iiitdmj.ac.in'
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope='function')
+def test_club():
+    return Club.objects.create(name='Bitbyte - The Programming Club',
+                               category='S&T',
+                               description='Some desc',
+                               email='theprogclub@iiitdmj.ac.in',
+                               logo='https://www.iiitdmj.ac.in/webix.iiitdmj.ac.in/tpclogo.png')
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope='function')
+def test_user():
+    return User.objects.create(email='test@user.com',
+                               first_name='test',
+                               last_name='User')
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope='function')
+def test_registration_request(test_user, test_club):
+    return ClubRegistrationRequest.objects.create(user=test_user,
+                                                  club=test_club,
+                                                  fee_submitted=True,
+                                                  status='Pending',
+                                                  remark='Some text')
+
+
+@pytest.fixture(scope='function')
+def client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def testCreateClubRegistrationRequest_ClubDoesNotExist_returnBadRequest(client, test_user):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    response = client.post('/clubs/19999/registration-requests/', {
+        'fee_submitted': True,
+        'status': 'Pending',
+        'remark': 'Some text'
+    })
+
+    # then
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data['detail'] == 'invalid request'
+
+
+@pytest.mark.django_db
+def testCreateClubRegistrationRequest_validRequest_returnHTTP201(client, test_user, test_club):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    response = client.post(f'/clubs/{test_club.id}/registration-requests/', {
+        'fee_submitted': True,
+        'status': 'Pending',
+        'remark': 'Some text'
+    })
+
+    # then
+
+    # Removing updated_at at the time of testing ('updated_at' & datetime.now() )
+    # can't be equal due to time delay  , time of updation and current time
+    response.data.pop('updated_at', None)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data == {'id': 1, 'user': test_user.id, 'club': test_club.id,
+                             'fee_submitted': True, 'status': 'Pending', 'remark': 'Some text'}
+
+
+@pytest.mark.django_db
+def testUpdateClubRegistrationRequest_nonAdminRequest_throwsForbidden(client, test_user, test_club,
+                                                                      test_registration_request):
+    # given
+    client.force_authenticate(test_user)
+
+    # when
+    url = f'/clubs/{test_club.id}/registration-requests/{test_registration_request.id}/'
+    response = client.put(url, {
+        'fee_submitted': True,
+        'remark': 'Late fees',
+        'status': 'Approved',
+    })
+
+    # then
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@ pytest.mark.django_db
+def testUpdateClubRegistration_adminReq_invalidRequest_returnNotFound(client):
+    # given
+    user = User.objects.create(
+        email='admin@user.com', first_name='admin', last_name='user', is_staff=True)
+    client.force_authenticate(user)
+
+    # when
+    response = client.put('/clubs/999/registration-requests/99/', {
+        'fee_submitted': True,
+        'remark': 'Late fees',
+        'status': 'Approved',
+    })
+
+    # then
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def testUpdateClubRegistrationRequest_adminRequestValidData_updated(client, test_club,
+                                                                    test_registration_request):
+    # given
+    user = User.objects.create(
+        email='admin@user.com', first_name='admin', last_name='user', is_staff=True)
+    client.force_authenticate(user)
+
+    # when
+    url = f'/clubs/{test_club.id}/registration-requests/{test_registration_request.id}/'
+    response = client.put(url, {
+        'fee_submitted': True,
+        'remark': 'Late fees',
+        'status': 'Approved',
+    })
+
+    # then
+    updated_registration_request = ClubRegistrationRequest.objects.get(
+        pk=test_registration_request.id)
+
+    # Only removing updated_at at the time of testing ('updated_at' & datetime.now() )
+    # can't be equal due to time delay  , time of updation and current time
+    response.data.pop('updated_at', None)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {'id': test_registration_request.id,
+                             'user': test_registration_request.user.id,
+                             'club': test_registration_request.club.id,
+                             'fee_submitted': True,
+                             'remark': 'Late fees',
+                             'status': 'Approved',
+                             'updated_by': user.id}
+    assert updated_registration_request.fee_submitted
+    assert updated_registration_request.remark == 'Late fees'
+    assert updated_registration_request.status == 'Approved'
+    assert updated_registration_request.updated_by == user
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('position', ['Coordinator', 'Co-Coordinator', 'Core member'])
+def testUpdateClubRegistrationRequest_coreMemberRequestValidData_updated(client,
+                                                                         position,
+                                                                         test_club,
+                                                                         test_registration_request):
+    # given
+    user = User.objects.create(
+        email='core@user.com', first_name='core', last_name='member')
+    client.force_authenticate(user)
+
+    Role.objects.create(name=position,
+                        club=test_club,
+                        user=user,
+                        assigned_at=date.today())
+
+    # when
+    url = f'/clubs/{test_club.id}/registration-requests/{test_registration_request.id}/'
+    response = client.put(url, {
+        'fee_submitted': True,
+        'remark': 'Late fees',
+        'status': 'Approved',
+    })
+
+    # then
+    updated_registration_request = ClubRegistrationRequest.objects.get(
+        pk=test_registration_request.id)
+
+    # Only removing updated_at at the time of testing ('updated_at' & datetime.now()
+    # can't be equal due to time delay  , time of updation and current time
+    response.data.pop('updated_at', None)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == {'id': test_registration_request.id,
+                             'user': test_registration_request.user.id,
+                             'club': test_registration_request.club.id,
+                             'fee_submitted': True,
+                             'remark': 'Late fees',
+                             'status': 'Approved',
+                             'updated_by': user.id}
+    assert updated_registration_request.fee_submitted
+    assert updated_registration_request.remark == 'Late fees'
+    assert updated_registration_request.status == 'Approved'
+    assert updated_registration_request.updated_by == user

--- a/api/api/clubs/urls.py
+++ b/api/api/clubs/urls.py
@@ -4,5 +4,8 @@ from . import views
 
 urlpatterns = [
     path('', views.ListClubsView.as_view()),
-    path('<int:pk>/', views.UpdateClubsView.as_view())
+    path('<int:pk>/', views.UpdateClubsView.as_view()),
+    path('<int:pk>/registration-requests/', views.CreateClubRegistrationRequestView.as_view()),
+    path('<int:club_id>/registration-requests/<int:registration_id>/',
+         views.UpdateClubRegistrationRequestView.as_view())
 ]

--- a/api/api/clubs/views.py
+++ b/api/api/clubs/views.py
@@ -1,8 +1,9 @@
-from rest_framework.generics import ListAPIView, UpdateAPIView
+from rest_framework.generics import CreateAPIView, ListAPIView, UpdateAPIView
 
-from .models import Club
-from .permissions import IsPositionHolderOrAdmin
-from .serializers import ClubSerializer
+from .models import Club, ClubRegistrationRequest
+from .permissions import IsCoreMemberOrAdmin, IsPositionHolderOrAdmin
+from .serializers import (ClubRegistrationRequestSerializer, ClubSerializer,
+                          ClubUpdateRegistrationRequestSerializer)
 
 
 class ListClubsView(ListAPIView):
@@ -14,3 +15,17 @@ class UpdateClubsView(UpdateAPIView):
     permission_classes = (IsPositionHolderOrAdmin,)
     queryset = Club.objects.all()
     serializer_class = ClubSerializer
+
+
+class CreateClubRegistrationRequestView(CreateAPIView):
+    queryset = ClubRegistrationRequest.objects.all()
+    serializer_class = ClubRegistrationRequestSerializer
+
+
+class UpdateClubRegistrationRequestView(UpdateAPIView):
+    permission_classes = (IsCoreMemberOrAdmin,)
+    serializer_class = ClubUpdateRegistrationRequestSerializer
+    lookup_url_kwarg = "registration_id"
+
+    def get_queryset(self):
+        return ClubRegistrationRequest.objects.filter(club=self.kwargs['club_id'])


### PR DESCRIPTION
Other things are the same. I have made changes in `api/clubs/serializers.py` and `api/clubs/tests.py` with respect to the following requested changes
![review_request](https://user-images.githubusercontent.com/86283785/186171793-3a2358cf-289d-4b43-98ad-b695a789cc02.jpg)
.